### PR TITLE
add an optional parameter to store the result of follow 

### DIFF
--- a/src/ffetch.js
+++ b/src/ffetch.js
@@ -100,13 +100,13 @@ function slice(upstream, context, from, to) {
   return limit(skip(upstream, context, from), context, to - from);
 }
 
-function follow(upstream, context, name, maxInFlight = 5) {
+function follow(upstream, context, name, newName, maxInFlight = 5) {
   const { fetch, parseHtml } = context;
   return map(upstream, context, async (entry) => {
     const value = entry[name];
     if (value) {
       const resp = await fetch(value);
-      return { ...entry, [name]: resp.ok ? parseHtml(await resp.text()) : null };
+      return { ...entry, [newName || name]: resp.ok ? parseHtml(await resp.text()) : null };
     }
     return entry;
   }, maxInFlight);

--- a/test/ffetch.js
+++ b/test/ffetch.js
@@ -275,6 +275,7 @@ describe('ffetch', () => {
           .first();
 
         assert(entry);
+        assert(entry.path === '/document');
         assert(entry.content);
       });
 

--- a/test/ffetch.js
+++ b/test/ffetch.js
@@ -241,14 +241,14 @@ describe('ffetch', () => {
     describe('sheet', () => {
       it('returns a generator for all entries of a given sheet', async () => {
         mockIndexRequests('/query-index.json', 555, 255, 'test');
-    
+
         const entries = ffetch('/query-index.json').withFetch(fetch).sheet('test');
         let i = 0;
         for await (const entry of entries) {
           assert.deepStrictEqual(entry, { title: `Entry ${i}` });
           i += 1;
         }
-    
+
         assert.equal(555, i);
       });
     });
@@ -264,6 +264,18 @@ describe('ffetch', () => {
 
         assert(entry);
         assert(entry.path);
+      });
+
+      it('stores the document result in a a new field', async () => {
+        mockDocumentRequest('/document');
+        mockIndexRequests('/query-index.json', 1, 255, null, () => ({ path: '/document' }));
+
+        const entry = await ffetch('/query-index.json').withFetch(fetch).withHtmlParser(parseDocument)
+          .follow('path', 'content')
+          .first();
+
+        assert(entry);
+        assert(entry.content);
       });
 
       it('returns null if the reference does not exist', async () => {


### PR DESCRIPTION
I found that using `.follow` loses any ability to use the path (e.g for linking to the page). If there is some other better way to do this currently, let me know.